### PR TITLE
updated submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ In your pull request description, you should include:
 | Harry Shin | 60.7% | [Wandb](https://api.wandb.ai/links/dh2shin2-stanford-university/45vxov1e) |  |
 | Rafael Prado Basto |              58.59% |  [link](./images/val_curves.jpg)     |                                   |
 | Karthik Dharmarajan |              57.70% |   [Wandb](https://api.wandb.ai/links/kdharmarajan/dxmx6vof)    |                          |
+| Ramgopal Venkateswaran |              53.34% |   [Wandb](https://api.wandb.ai/links/ramvenkat98/mz5g2i17)    |                          |
 | Brandon Snider |              48.83% |   [Wandb](https://api.wandb.ai/links/brandon-snider-stanford-university/n8t743my)    |                          |
 | Harshvardhan Agarwal | 43.56% | [Wandb](https://api.wandb.ai/links/tokenization/hnclbrtw) | |
 | Ryan Zhao| 42.48% | [wandb](https://api.wandb.ai/links/knightasterial-stanforduniversity/9sw1cimh) | |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In your pull request description, you should include:
 | Puheng Li              |              58.1%  | [Wandb](https://api.wandb.ai/links/puhengli-stanford-university/t3gm8jcd)                |                                     |
 | Angela Liu             |              58.02% | [Wandb](https://api.wandb.ai/links/aliu917/1d8hco5a)                                     |                                     |
 | Karthik Dharmarajan    |              57.70% | [Wandb](https://api.wandb.ai/links/kdharmarajan/dxmx6vof)                                |                                     |
-| Ramgopal Venkateswaran    |              57.38% | [Wandb](https://api.wandb.ai/links/ramvenkat98/dplett9b)                                |                                     |
+| Ramgopal Venkateswaran |              57.38% | [Wandb](https://api.wandb.ai/links/ramvenkat98/dplett9b)                                 |                                     |
 | Pinlin (Calvin) Xu     |              56.24% | [Wandb](https://api.wandb.ai/links/pinlinxu-lab/e9t16kjy)                                |                                     |
 | Adam Zhao              |              56.04% | https://api.wandb.ai/links/zhao1adam-stanford-university/xntcnjj7                        |                                     |
 | Suze van Adrichem      |              53.68% | [Wandb](https://api.wandb.ai/links/suzevana/ivy9vchh)                                    |                                     | 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ In your pull request description, you should include:
 | Puheng Li              |              58.1%  | [Wandb](https://api.wandb.ai/links/puhengli-stanford-university/t3gm8jcd)                |                                     |
 | Angela Liu             |              58.02% | [Wandb](https://api.wandb.ai/links/aliu917/1d8hco5a)                                     |                                     |
 | Karthik Dharmarajan    |              57.70% | [Wandb](https://api.wandb.ai/links/kdharmarajan/dxmx6vof)                                |                                     |
+| Ramgopal Venkateswaran    |              57.38% | [Wandb](https://api.wandb.ai/links/ramvenkat98/dplett9b)                                |                                     |
 | Pinlin (Calvin) Xu     |              56.24% | [Wandb](https://api.wandb.ai/links/pinlinxu-lab/e9t16kjy)                                |                                     |
 | Adam Zhao              |              56.04% | https://api.wandb.ai/links/zhao1adam-stanford-university/xntcnjj7                        |                                     |
 | Suze van Adrichem      |              53.68% | [Wandb](https://api.wandb.ai/links/suzevana/ivy9vchh)                                    |                                     | 


### PR DESCRIPTION
Model Hyperparameters:
* On-Policy GRPO
* Learning Rate 5e-5 - did introduce more instability; 3e-5 was more stable but overfit and converged at a smaller validation accuracy
* Kept Std Normalization
* Increased Rollouts + Batch Size (Group Size 16, Train Batch Size = Rollout Batch Size = 512)

Data Sampling Logic:
* Curriculum based on weighting each sample as follows:
    * add 10 to the weight if never seen before
    * add (1 - p(correct)) to the weight where p(correct) is the number of correct rollouts over that prompt’s prior rollouts
    * add 0.25 uniformly

The curriculum is in the final run but it seems like it would likely be because it forces the model to see new examples early on and discourages it from overfitting by seeing the same examples quickly. The (1 - p(correct)) part alone doesn’t seem to do much, and we could reproduce most of the gain from the curriculum by just iterating through the samples in order of least seen to most seen (instead of doing random resampling each time).

Did Not Work:
* Varying batch sizes and learning rates over the course of the training run
    * Up to train step 90, using train batch size = rollout batch size = 256, group size = 8
    * Up to train step 200, increasing batch sizes to 1024 and group size to 32
    * Decreasing learning rate after train step 200

This was removed in the end - the increase in rollout sizes midway through performed comparably to increasing rollout sizes from the start itself (rather than midway), which was done in the end. Decreasing the learning rate hurt rather than helped (which makes sense because the model is not constrained in terms of under-fitting the prompts, it tends to overfit and achieve very high accuracy on the train prompts.)