### PR TITLE
Pushing my results

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ In your pull request description, you should include:
 | Name                   | Validation Accuracy | Link                                                                                     | Verification status (leave empty)   |
 | :--------------------- | ------------------: | ---------------------------------------------------------------------------------------: | ----------------------------------: |
 | Yihan Lai              |              66.5%  | [Wandb](https://api.wandb.ai/links/ihan-lai0924-stanford-university/yxg3x15l)            |                                     |
+| atj10              |              66.3%  | [Wandb](https://api.wandb.ai/links/dabs/jlf2007m)            |                                     |
 | Tony Ye                |              65.88% | [Wandb](https://api.wandb.ai/links/junzeye-stanford-university/kvl8tyds)                 |                                     |
 | Harry Shin             |              60.7%  | [Wandb](https://api.wandb.ai/links/dh2shin2-stanford-university/45vxov1e)                |                                     |
 | Rafael Prado Basto     |              58.59% | [link](./images/val_curves.jpg)                                                          |                                     |


### PR DESCRIPTION
Reached a validation accuracy (and avg_answer_reward) of 0.663. 

Here is the command I ran:

srun --partition=a5-batch --qos=a5-batch-qos --gpus=1 -c 4 --mem 100G --nodes 1 uv run python grpo_off_policy.py --learning_rate 4e-5 --loss_type reinforce_with_baseline --use_std_normalization --epochs_per_rollout_batch 1 --train_batch_size 256 --gradient_accumulation_steps 128 --n_grpo_steps 500 --eval_frequency 10


The group size (G) was 8 by default in my grope_off_policy.py script. I used masked_mean. 

One small change to make to my submission (in case you wanna replicate):

Comment out the following code in grpo_off_policy.py

            # Evaluate on subset for speed during training
            val_subset_size = min(1000, len(val_data))
            val_subset = val_data[:val_subset_size]
            val_prompts_subset = val_prompts[:val_subset_size]
            
            eval_results = evaluate_vllm(
                vllm_model,
                r1_zero_reward_fn,
                val_prompts_subset,
                val_subset,
                eval_sampling_params
            )
       
and replace it with this:

         eval_results = evaluate_vllm(
                vllm_model,
                r1_zero_reward_fn,
                val_prompts,
                val_data,
                eval_sampling_params
            )
       
This does not change any logic, all it does is changes the evaluation from being on a 1000 examples to the full 5000  validation set. 