### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ In your pull request description, you should include:
 | Yihan Lai              |              64.7%  | [Wandb](https://api.wandb.ai/links/ihan-lai0924-stanford-university/yxg3x15l)            |                                     |
 | Stephen Ge             |              63.04% | [Wandb](https://api.wandb.ai/links/stephenge/8ykmfla9)                                   |                                     |
 | Joonhyuk Lee           |              62.24% | [Wandb](https://api.wandb.ai/links/joonhyuk-stanford-university/u18wzqc3)                |                                     |
+| Michael Bereket        |              61.8%  | [Wandb](https://api.wandb.ai/links/mbereket/lhc83n35)                                    |                                     |
 | Prateek Varshney       |              61.5%  | [Wandb](https://api.wandb.ai/links/stanfordcs/i63ohasr)                                  |                                     |
 | Harry Shin             |              60.7%  | [Wandb](https://api.wandb.ai/links/dh2shin2-stanford-university/45vxov1e)                |                                     |
 | Kyler Wang             |              58.92% | [Wandb](https://api.wandb.ai/links/kylerwang-stanford-university/jnlags7e  )             |                                     |


### PR DESCRIPTION
On policy GRPO with rollout and train batch size of 512, lr 2e-5, and micro batch size 1. Other hyperparameters are defaults from the assignment. Training was somewhat unstable across runs with this learning rate, but it achieved the best peak result compared to lower / more stable learning rates.

I ran some experiments to try to identify the source of the instability but have not reached a strong conclusion, if submission was based on an aggregate of runs I would probably select a lower learning rate.